### PR TITLE
Narrow default on adt matchers

### DIFF
--- a/packages/morphic-adt/dtslint/ts3.8/index.ts
+++ b/packages/morphic-adt/dtslint/ts3.8/index.ts
@@ -1,1 +1,43 @@
-const dummy = 42 // $ExpectType 42
+import { makeADT, ofType } from '../../src'
+
+interface Foo {
+  type: 'foo'
+  a: string
+  b: number
+}
+
+interface Bar {
+  type: 'bar'
+  c: string
+  d: number
+}
+
+interface Baz {
+  type: 'baz'
+  e: string
+  f: number
+}
+
+const fooBar = makeADT('type')({
+  foo: ofType<Foo>(),
+  bar: ofType<Bar>(),
+  baz: ofType<Baz>()
+})
+
+fooBar.matchWiden({}, x => x) // $ExpectType (a: Foo | Bar | Baz) => Foo | Bar | Baz
+fooBar.matchWiden({ foo: () => (undefined as any) as never }, x => x) // $ExpectType (a: Foo | Bar | Baz) => Bar | Baz
+fooBar.matchWiden({ foo: x => x.type, bar: x => x.type, baz: x => x.type }) // $ExpectType (a: Foo | Bar | Baz) => "foo" | "bar" | "baz"
+
+// $ExpectType (a: Foo | Bar | Baz) => string
+fooBar.match(
+  { foo: _x => '', bar: _x => '' },
+  _x => '1' // $ExpectType (_x: Foo | Bar | Baz) => string
+)
+
+// $ExpectType Reducer<number, Foo | Bar | Baz>
+fooBar.createReducer(0)(
+  {
+    foo: foo => n => n + foo.a.length
+  },
+  bar_baz => n => n + bar_baz.type.length // $ExpectType (bar_baz: Bar | Baz) => (n: number) => number
+)

--- a/packages/morphic-adt/src/matcher.ts
+++ b/packages/morphic-adt/src/matcher.ts
@@ -18,14 +18,7 @@ interface Matcher<A, Tag extends keyof A> extends MatcherInter<A, ValueByKeyByTa
 interface MatcherInter<A, Record> {
   <R>(match: Cases<Record, R>): (a: A) => R
   // tslint:disable-next-line: unified-signatures
-  <
-    R,
-    M extends Partial<Cases<Record, R>>,
-    D extends (_: { [k in keyof Record]: Record[k] }[Exclude<keyof Record, keyof M>]) => R
-  >(
-    match: M,
-    def: D
-  ): (a: A) => R
+  <R>(match: Partial<Cases<Record, R>>, def: (_: { [k in keyof Record]: Record[k] }[keyof Record]) => R): (a: A) => R
 }
 
 interface Transform<A, Tag extends keyof A> extends TransformInter<A, ValueByKeyByTag<A>[Tag]> {}

--- a/packages/morphic-adt/test/adt.spec.ts
+++ b/packages/morphic-adt/test/adt.spec.ts
@@ -71,10 +71,12 @@ describe('Builder', () => {
     })
 
     it('match with default', () => {
-      const matcherDefault = match({
-        bar: ({ c }) => c,
-        default: () => 'defaultResult'
-      })
+      const matcherDefault = match(
+        {
+          bar: ({ c }) => c
+        },
+        () => 'defaultResult'
+      )
       chai.assert.deepStrictEqual(matcherDefault(barA), 'a', 'barA')
       chai.assert.deepStrictEqual(matcherDefault(fooA), 'defaultResult', 'fooA')
     })
@@ -89,28 +91,34 @@ describe('Builder', () => {
       chai.assert.deepStrictEqual(matcherW(fooA), 'a', 'fooA')
     })
     it('matchWiden with default', () => {
-      const matcherDefaultW = matchWiden({
-        bar: ({ c }) => c.length,
-        default: () => 'defaultResult'
-      })
+      const matcherDefaultW = matchWiden(
+        {
+          bar: ({ c }) => c.length
+        },
+        () => 'defaultResult'
+      )
       chai.assert.deepStrictEqual(matcherDefaultW(barA), 1, 'bar')
       chai.assert.deepStrictEqual(matcherDefaultW(fooA), 'defaultResult', 'fooA')
     })
 
     it('matchWiden with default expose the action', () => {
-      const matcherDefaultW = matchWiden({
-        bar: ({ c }) => c.length,
-        default: a => a
-      })
+      const matcherDefaultW = matchWiden(
+        {
+          bar: ({ c }) => c.length
+        },
+        a => a
+      )
       chai.assert.deepStrictEqual(matcherDefaultW(barA), 1, 'barA')
-      chai.assert.deepStrictEqual(matcherDefaultW(fooA), fooA, 'fooA')
+      chai.assert.deepStrictEqual(matcherDefaultW(fooA), fooA as number | Foo, 'fooA')
     })
 
     it('reduce', () => {
-      const reduce = createReducer({ x: '0' })({
-        foo: () => ({ x }) => ({ x: `foo(${x})` }),
-        default: () => () => ({ x: `default` })
-      })
+      const reduce = createReducer({ x: '0' })(
+        {
+          foo: () => ({ x }) => ({ x: `foo(${x})` })
+        },
+        () => () => ({ x: `default` })
+      )
 
       chai.assert.deepStrictEqual(reduce(undefined, fooA), { x: 'foo(0)' })
       chai.assert.deepStrictEqual(reduce({ x: '1' }, fooA), { x: 'foo(1)' })
@@ -129,10 +137,12 @@ describe('Builder', () => {
     })
 
     it('reduce with default does not change state on unknown Action', () => {
-      const reduce = createReducer({ x: '0' })({
-        foo: () => ({ x }) => ({ x: `foo(${x})` }),
-        default: () => ({ x }) => ({ x: `default(${x})` })
-      })
+      const reduce = createReducer({ x: '0' })(
+        {
+          foo: () => ({ x }) => ({ x: `foo(${x})` })
+        },
+        () => ({ x }) => ({ x: `default(${x})` })
+      )
       const wrongAction = { type: 'unknown' }
       chai.assert.deepStrictEqual(reduce({ x: '1' }, wrongAction as any), {
         x: '1'
@@ -151,10 +161,12 @@ describe('Builder', () => {
     })
 
     it('reduce return the previous state', () => {
-      const reduce = createReducer({ x: '0' })({
-        foo: () => ({ x }) => ({ x: `foo(${x})` }),
-        default: () => identity
-      })
+      const reduce = createReducer({ x: '0' })(
+        {
+          foo: () => ({ x }) => ({ x: `foo(${x})` })
+        },
+        () => identity
+      )
       chai.assert.deepStrictEqual(reduce(undefined, barA), { x: '0' })
     })
 


### PR DESCRIPTION
The only issue is with plain `match`:

```ts
// $ExpectType (a: Foo | Bar | Baz) => string
fooBar.match(
  { foo: _x => '', bar: _x => '' },
  _x => '1' // $ExpectType (_x: Foo | Bar | Baz) => string
)
```

To be able to narrow here we would have to curry, we have 2 options:
1) remove match all-together (it is a special case of matchWiden with type fixed)
2) keep it this way (it is effectively equipotent to the previous)

For the rest matchWiden & reducer works perfectly

```ts
// $ExpectType Reducer<number, Foo | Bar | Baz>
fooBar.createReducer(0)(
  {
    foo: foo => n => n + foo.a.length
  },
  bar_baz => n => n + bar_baz.type.length // $ExpectType (bar_baz: Bar | Baz) => (n: number) => number
)
```

```ts
fooBar.matchWiden({}, x => x) // $ExpectType (a: Foo | Bar | Baz) => Foo | Bar | Baz
fooBar.matchWiden({ foo: () => (undefined as any) as never }, x => x) // $ExpectType (a: Foo | Bar | Baz) => Bar | Baz
fooBar.matchWiden({ foo: x => x.type, bar: x => x.type, baz: x => x.type }) // $ExpectType (a: Foo | Bar | Baz) => "foo" | "bar" | "baz"
```