### PR TITLE
Added docs for how to import AType and EType

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Beware that using this with `taggedUnion` (or `tagged` construct) is very ineffi
 You may use this pattern
 
 ```typescript
+import type { AType, EType } from '@morphic-ts/summoners'
+
 const Car_ = summon(F =>
   F.interface(
     {


### PR DESCRIPTION
Every time I try to use Opaque normal types in a project I always have to clone the project and search for the import to remember how it's done. Let's add this to the docs to save me and probably others a lot of time trying to figure out how to import this.